### PR TITLE
Add pagination and filters to offers

### DIFF
--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::OffersController < ApplicationController
 
   # GET /offers
   def index
-    @offers = Offer.all
+    @offers = Offer.all.order(created_at: :desc)
   end
 
   # GET /offers/1

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -7,12 +7,16 @@ class Api::V1::OffersController < ApplicationController
   # Params:
   #   - limit: (default: 50) Number of offers to display
   #   - offset: (default: 0) Number of offers to skip first
-  # Why offset instead of commonly used page?
-  # When changing number of items displayed on page you can still get right starting offer on page.
+  #     Why offset instead of commonly used page number?
+  #     When changing number of items displayed on page you can still get right starting offer on page.
+  #   - min_price: (default: any) minimum price inclusive
+  #   - max_price: (default: any) maximum price inclusive
   def index
     limit = params[:limit].to_i.positive? ? params[:limit].to_i : 50
     offset = params[:offset].to_i.positive? ? params[:offset].to_i : 0
     @offers = Offer.all.order(created_at: :desc).limit(limit).offset(offset)
+    @offers.where!('price >= ?', params[:min_price].to_f) if params[:min_price]&.match? /\A\d+(\.\d+)?\Z/
+    @offers.where!('price <= ?', params[:max_price].to_f) if params[:max_price]&.match? /\A\d+(\.\d+)?\Z/
   end
 
   # GET /offers/1

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -19,7 +19,10 @@ class Api::V1::OffersController < ApplicationController
     @offers = Offer.all.order(created_at: :desc).limit(limit).offset(offset)
     @offers.where!('price >= ?', params[:min_price].to_f) if params[:min_price]&.match? /\A\d+(\.\d+)?\Z/
     @offers.where!('price <= ?', params[:max_price].to_f) if params[:max_price]&.match? /\A\d+(\.\d+)?\Z/
-    @offers.where!('title LIKE ? OR description LIKE ?', params[:query], params[:query]) if params[:query]
+    if params[:query]
+      q = "%#{params[:query]}%"
+      @offers.where!('title LIKE ? OR description LIKE ?', q, q)
+    end
   end
 
   # GET /offers/1

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -11,12 +11,15 @@ class Api::V1::OffersController < ApplicationController
   #     When changing number of items displayed on page you can still get right starting offer on page.
   #   - min_price: (default: any) minimum price inclusive
   #   - max_price: (default: any) maximum price inclusive
+  #   - query: text (exact) to search in title and description
+  #     Please note, this is ineffective and should be used with caution
   def index
     limit = params[:limit].to_i.positive? ? params[:limit].to_i : 50
     offset = params[:offset].to_i.positive? ? params[:offset].to_i : 0
     @offers = Offer.all.order(created_at: :desc).limit(limit).offset(offset)
     @offers.where!('price >= ?', params[:min_price].to_f) if params[:min_price]&.match? /\A\d+(\.\d+)?\Z/
     @offers.where!('price <= ?', params[:max_price].to_f) if params[:max_price]&.match? /\A\d+(\.\d+)?\Z/
+    @offers.where!('title LIKE ? OR description LIKE ?', params[:query], params[:query]) if params[:query]
   end
 
   # GET /offers/1

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -1,11 +1,18 @@
-# frozen_string_literal: true"
+# frozen_string_literal: true
 
 class Api::V1::OffersController < ApplicationController
   before_action :set_offer, only: %i[show update destroy]
 
   # GET /offers
+  # Params:
+  #   - limit: (default: 50) Number of offers to display
+  #   - offset: (default: 0) Number of offers to skip first
+  # Why offset instead of commonly used page?
+  # When changing number of items displayed on page you can still get right starting offer on page.
   def index
-    @offers = Offer.all.order(created_at: :desc)
+    limit = params[:limit].to_i || 50
+    offset = params[:offset].to_i || 0
+    @offers = Offer.all.order(created_at: :desc).limit(limit).offset(offset)
   end
 
   # GET /offers/1

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::OffersController < ApplicationController
   # Why offset instead of commonly used page?
   # When changing number of items displayed on page you can still get right starting offer on page.
   def index
-    limit = params[:limit].to_i || 50
-    offset = params[:offset].to_i || 0
+    limit = params[:limit].to_i.positive? ? params[:limit].to_i : 50
+    offset = params[:offset].to_i.positive? ? params[:offset].to_i : 0
     @offers = Offer.all.order(created_at: :desc).limit(limit).offset(offset)
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,6 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-FactoryBot.create_list(:offer, 100)
+unless Rails.env.test?
+  FactoryBot.create_list(:offer, 100)
+end

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe Api::V1::OffersController, type: :controller do
         expect(assigns(:offers).count).to eq(1)
       end
     end
+    describe 'query text' do
+      before do
+        FactoryBot.create(:offer, title: 'Example text to search')
+        FactoryBot.create(:offer, description: 'Example text to search in description')
+        FactoryBot.create(:offer)
+      end
+      it 'search in title and description case insensitive' do
+        get :index, params: { query: 'example text' }, session: valid_session, format: 'json'
+        expect(assigns(:offers).size).to eq(2)
+      end
+      it 'escapes characters' do
+        get :index, params: { query: "\"' OR 1=1 -- " }, session: valid_session, format: 'json'
+        expect(assigns(:offers).count).to eq(0)
+      end
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -13,15 +13,23 @@ RSpec.describe Api::V1::OffersController, type: :controller do
       get :index, params: {}, session: valid_session, format: 'json'
       expect(response).to be_successful
     end
-    it 'returns all offers' do
-      Offer.create! valid_attributes
-      get :index, params: {}, session: valid_session, format: 'json'
-      expect(assigns(:offers).size).to eq(Offer.all.count)
-    end
     it 'returns newest offer first' do
       offers = FactoryBot.create_list(:offer, 10)
       get :index, params: {}, session: valid_session, format: 'json'
       expect(assigns(:offers).first).to eq(offers.last)
+    end
+    describe 'limit and offset parameter' do
+      it 'limit offers' do
+        FactoryBot.create_list(:offer, 10)
+        get :index, params: { limit: 5 }, session: valid_session, format: 'json'
+        expect(assigns(:offers).size).to eq(5)
+      end
+      it 'limit offers and skip 5' do
+        offers = FactoryBot.create_list(:offer, 10)
+        # we should get offers id 6 to id 2 (as from newest to oldest)
+        get :index, params: { limit: 5, offset: 4 }, session: valid_session, format: 'json'
+        expect(assigns(:offers).first).to eq(offers[5]) # id 6 is 5th element
+      end
     end
   end
 

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Api::V1::OffersController, type: :controller do
       get :index, params: {}, session: valid_session, format: 'json'
       expect(assigns(:offers).size).to eq(Offer.all.count)
     end
+    it 'returns newest offer first' do
+      offers = FactoryBot.create_list(:offer, 10)
+      get :index, params: {}, session: valid_session, format: 'json'
+      expect(assigns(:offers).first).to eq(offers.last)
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -36,6 +36,25 @@ RSpec.describe Api::V1::OffersController, type: :controller do
         expect(assigns(:offers).first).to eq(offers[5]) # id 6 is 5th element
       end
     end
+    describe 'min and max price' do
+      before do
+        FactoryBot.create(:offer, price: 1000.00)
+        FactoryBot.create(:offer, price: 2000.00)
+        FactoryBot.create(:offer, price: 3000.33)
+      end
+      it 'limits max price' do
+        get :index, params: { max_price: 3000.30 }, session: valid_session, format: 'json'
+        expect(assigns(:offers).size).to eq(2)
+      end
+      it 'limits min price' do
+        get :index, params: { min_price: 2000 }, session: valid_session, format: 'json'
+        expect(assigns(:offers).count).to eq(2)
+      end
+      it 'limits both min and max price' do
+        get :index, params: { min_price: 2000, max_price: 3000 }, session: valid_session, format: 'json'
+        expect(assigns(:offers).count).to eq(1)
+      end
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Api::V1::OffersController, type: :controller do
       expect(assigns(:offers).first).to eq(offers.last)
     end
     describe 'limit and offset parameter' do
+      it 'default to 50 offers' do
+        FactoryBot.create_list(:offer, 60)
+        get :index, params: {}, session: valid_session, format: 'json'
+        expect(assigns(:offers).size).to eq(50)
+      end
       it 'limit offers' do
         FactoryBot.create_list(:offer, 10)
         get :index, params: { limit: 5 }, session: valid_session, format: 'json'


### PR DESCRIPTION
Add pagination and filters to offers.

Please note, current API implementation does not allow to return results count. Adding this now would be breaking change. We need new API version.